### PR TITLE
Improved palette handling in ImageOps

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -130,8 +130,9 @@ def test_pad():
             )
 
 
-def test_palette():
-    im = hopper("P")
+@pytest.mark.parametrize("mode", ("P", "PA"))
+def test_palette(mode):
+    im = hopper(mode)
 
     # Expand
     expanded_im = ImageOps.expand(im)

--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -130,6 +130,20 @@ def test_pad():
             )
 
 
+def test_palette():
+    im = hopper("P")
+
+    # Expand
+    expanded_im = ImageOps.expand(im)
+    assert_image_equal(im.convert("RGB"), expanded_im.convert("RGB"))
+
+    # Pad
+    padded_im = ImageOps.pad(im, (256, 128), centering=(0, 0))
+    assert_image_equal(
+        im.convert("RGB"), padded_im.convert("RGB").crop((0, 0, 128, 128))
+    )
+
+
 def test_pil163():
     # Division by zero in equalize if < 255 pixels in image (@PIL163)
 

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -21,7 +21,7 @@ import functools
 import operator
 import re
 
-from . import Image
+from . import Image, ImagePalette
 
 #
 # helpers
@@ -292,7 +292,7 @@ def pad(image, size, method=Image.Resampling.BICUBIC, color=None, centering=(0.5
     else:
         out = Image.new(image.mode, size, color)
         if resized.palette:
-            out.putpalette(resized.palette)
+            out.putpalette(resized.getpalette())
         if resized.width != size[0]:
             x = int((size[0] - resized.width) * max(0, min(centering[0], 1)))
             out.paste(resized, (x, 0))
@@ -399,8 +399,7 @@ def expand(image, border=0, fill=0):
     height = top + image.size[1] + bottom
     color = _color(fill, image.mode)
     if image.mode == "P" and image.palette:
-        image.load()
-        palette = image.palette.copy()
+        palette = ImagePalette.ImagePalette(palette=image.getpalette())
         if isinstance(color, tuple):
             color = palette.getcolor(color)
     else:

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -291,9 +291,8 @@ def pad(image, size, method=Image.Resampling.BICUBIC, color=None, centering=(0.5
         out = resized
     else:
         out = Image.new(image.mode, size, color)
-        palette = image.palette.copy()
-        if palette:
-            out.putpalette(palette)
+        if resized.palette:
+            out.putpalette(resized.palette)
         if resized.width != size[0]:
             x = int((size[0] - resized.width) * max(0, min(centering[0], 1)))
             out.paste(resized, (x, 0))

--- a/src/PIL/ImageOps.py
+++ b/src/PIL/ImageOps.py
@@ -398,7 +398,7 @@ def expand(image, border=0, fill=0):
     width = left + image.size[0] + right
     height = top + image.size[1] + bottom
     color = _color(fill, image.mode)
-    if image.mode == "P" and image.palette:
+    if image.palette:
         palette = ImagePalette.ImagePalette(palette=image.getpalette())
         if isinstance(color, tuple):
             color = palette.getcolor(color)


### PR DESCRIPTION
Three suggestions here for https://github.com/python-pillow/Pillow/pull/6596

1. You may have noticed that the tests are failing your pull request, with the error `AttributeError: 'NoneType' object has no attribute 'copy'`. This is because not all images have a palette. The palette doesn't actually need to be duplicated though, so I've removed the `copy()` operation.
2. I've added a test, to help prevent your change from being unintentionally broken in the future. After writing the test, I found that it was necessary to use `getpalette()`, and that `ImageOps.expand()` could also benefit from this change.
3. I notice that your code doesn't explicitly check the mode, allowing the palette data to be copied for both P and PA images. This is a good idea, and I've made that change for `ImageOps.expand()` as well.